### PR TITLE
Locked down comments edit delete (#2)

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,14 @@
 class CommentsController < ApplicationController
   before_action :set_comment, only: %i[ show edit update destroy ]
 
+  before_action :ensure_owner_is_current_user, only: %i[ edit update destroy ]
+
+  def ensure_owner_is_current_user
+    if @comment.author != current_user
+      redirect_back fallback_location: root_path, alert: "Nice try, suckah!"
+    end 
+  end
+
   # GET /comments or /comments.json
   def index
     @comments = Comment.all

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -7,15 +7,17 @@
           <%= link_to comment.author.username, user_path(comment.author.username), class: "text-dark" %>
         </h5>
 
-        <div>
-          <%= link_to edit_comment_path(comment), class: "btn btn-link btn-sm text-muted" do %>
-            <i class="fas fa-edit fa-fw"></i>
-          <% end %>
+        <% if comment.author == current_user %>
+          <div>
+            <%= link_to edit_comment_path(comment), class: "btn btn-link btn-sm text-muted" do %>
+              <i class="fas fa-edit fa-fw"></i>
+            <% end %>
 
-          <%= link_to comment, method: :delete, class: "btn btn-link btn-sm text-muted" do %>
-            <i class="fas fa-trash fa-fw"></i>
-          <% end %>
-        </div>
+            <%= link_to comment, method: :delete, class: "btn btn-link btn-sm text-muted" do %>
+              <i class="fas fa-trash fa-fw"></i>
+            <% end %>
+          </div>
+        <% end %>
       </div>
       <p><%= comment.body %></p>
     </div>


### PR DESCRIPTION
added back in function to lock down comments (users can only edit and delete their own comments). This was lost in the first merge for some reasons
user can only see their own pending follow requests